### PR TITLE
Prevent unnecessary rerender on map move end

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "classnames": "^2.3.1",
         "gh-pages": "^4.0.0",
         "leaflet": "^1.8.0",
+        "lodash": "^4.17.21",
         "prop-types": "^15.8.1",
         "react": "^17.0.2",
         "react-dom": "^17.0.2",
@@ -8690,7 +8691,8 @@
     },
     "node_modules/lodash": {
       "version": "4.17.21",
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
     },
     "node_modules/lodash.debounce": {
       "version": "4.0.8",
@@ -18679,7 +18681,9 @@
       }
     },
     "lodash": {
-      "version": "4.17.21"
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
     },
     "lodash.debounce": {
       "version": "4.0.8"

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "classnames": "^2.3.1",
     "gh-pages": "^4.0.0",
     "leaflet": "^1.8.0",
+    "lodash": "^4.17.21",
     "prop-types": "^15.8.1",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",

--- a/src/components/Map.js
+++ b/src/components/Map.js
@@ -11,6 +11,7 @@ import {
 import Supercluster from "supercluster";
 import iconMap from "../utils/iconMap";
 import { calcRating } from "../utils/rating";
+import isEqual from "lodash/isEqual";
 import "../stylesheets/supercluster.scss";
 import "../stylesheets/map.scss";
 
@@ -132,17 +133,18 @@ const Map = ({ onMarkerClick }) => {
       moveend: () => {
         if (index) {
           const bounds = map.getBounds();
-          setMarkers(
-            index.getClusters(
-              [
-                bounds.getWest(),
-                bounds.getSouth(),
-                bounds.getEast(),
-                bounds.getNorth(),
-              ],
-              map.getZoom()
-            )
+          const newPointers = index.getClusters(
+            [
+              bounds.getWest(),
+              bounds.getSouth(),
+              bounds.getEast(),
+              bounds.getNorth(),
+            ],
+            map.getZoom()
           );
+          if (!isEqual(newPointers, markers)) {
+            setMarkers(newPointers);
+          }
         }
       },
     });


### PR DESCRIPTION
Use deep compare to make sure markers are only rerendered when the clustering algorithm returns a modified marker set. Using lodash for now to do deep compare because I'm lazy but can easily swap out for a custom deep compare function.